### PR TITLE
No pods

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -2,12 +2,16 @@
  :source-paths #{"src"}
  :dependencies '[[org.clojure/clojure "1.6.0"      :scope "provided"]
                  [boot/core           "2.0.0"      :scope "provided"]
-                 [adzerk/bootlaces    "0.1.11"     :scope "test"]])
+                 [adzerk/bootlaces    "0.1.11"     :scope "test"]
+                 [org.clojure/tools.namespace "0.2.11"
+                  :exclusions [org.clojure/clojure]]
+                 [pjstadig/humane-test-output "0.6.0"
+                  :exclusions [org.clojure/clojure]]])
 
 (require '[adzerk.bootlaces :refer :all]
          '[mischov.boot-test :refer [test]])
 
-(def +version+ "1.0.7")
+(def +version+ "1.0.8")
 
 (bootlaces! +version+)
 

--- a/src/mischov/boot_test.clj
+++ b/src/mischov/boot_test.clj
@@ -1,76 +1,68 @@
 (ns mischov.boot-test
   {:boot/export-tasks true}
   (:refer-clojure :exclude [test])
-  (:require [boot.pod  :as pod]
-            [boot.core :as core]))
+  (:require [boot.core :as core]
+            [clojure.java.io :as io]
+            [clojure.test :as t]
+            [clojure.test.junit :as tj]
+            [clojure.tools.namespace.find :as namespace-find]
+            [clojure.tools.namespace.repl :as namespace-repl]
+            [pjstadig.humane-test-output :refer [activate!]]
+            ))
 
-(def pod-deps
-  '[[org.clojure/tools.namespace "0.2.11" :exclusions [org.clojure/clojure]]
-    [pjstadig/humane-test-output "0.6.0"  :exclusions [org.clojure/clojure]]])
+(activate!)
 
-(defn init [fresh-pod]
-  (doto fresh-pod
-    (pod/with-eval-in
-     (require '[clojure.test :as t]
-              '[clojure.test.junit :as tj]
-              '[clojure.java.io :as io]
-              '[pjstadig.humane-test-output :refer [activate!]]
-              '[clojure.tools.namespace.find :as namespace-find])
-     (activate!)
+(defonce repeated? false)
+
+;; Get all namespaces.
+(defn get-all-ns [dirs]
+  (let [dirs' (map (memfn getPath) dirs)]
+    (mapcat #(namespace-find/find-namespaces-in-dir (io/file %)) dirs')))
      
-     ;; Get all namespaces.
-     (defn get-all-ns [& dirs]
-       (-> (mapcat #(namespace-find/find-namespaces-in-dir (io/file %)) dirs)))
+;; Narrow down namespaces.
+(defn filter-namespaces
+  [namespaces regex]
+  (if regex
+    (filter #(re-find regex (str %)) namespaces)
+    namespaces))
+
+;; Custom core.test impls that support test filtering.
+(defn test-ns
+  [pred ns]
+  (binding [t/*report-counters* (ref t/*initial-report-counters*)]
+    (let [ns-obj (the-ns ns)]
+      (t/do-report {:type :begin-test-ns :ns ns-obj})
+      (t/test-vars (filter pred (vals (ns-interns ns-obj))))
+      (t/do-report {:type :end-test-ns :ns ns-obj}))
+    @t/*report-counters*))
+
+(defn run-tests
+  ([pred] (run-tests pred *ns*))
+  ([pred & namespaces]
+   (let [summary (assoc (apply merge-with + (map #(test-ns pred %)
+                                                 namespaces))
+                        :type :summary)]
+     (t/do-report summary)
+     summary)))
      
-     ;; Narrow down namespaces.
-     (defn filter-namespaces
-       [namespaces regex]
-       (if regex
-         (filter #(re-find regex (str %)) namespaces)
-         namespaces))
+;; Run tests.
+(defn test-with-formatting
+  [pred formatter namespaces]
+  (case formatter
+    :junit (tj/with-junit-output
+             (apply run-tests pred namespaces))
+    (apply run-tests pred namespaces)))
 
-     ;; Custom core.test impls that support test filtering.
-     (defn test-ns
-       [pred ns]
-       (binding [t/*report-counters* (ref t/*initial-report-counters*)]
-         (let [ns-obj (the-ns ns)]
-           (t/do-report {:type :begin-test-ns :ns ns-obj})
-           (t/test-vars (filter pred (vals (ns-interns ns-obj))))
-           (t/do-report {:type :end-test-ns :ns ns-obj}))
-         @t/*report-counters*))
+(defn boot-run-tests
+  [pred output-path formatter namespaces]
+  (if output-path
+    (with-open [writer (io/writer output-path)]
+      (binding [t/*test-out* writer]
+        (test-with-formatting pred formatter namespaces)))
+    (test-with-formatting pred formatter namespaces)))
 
-     (defn run-tests
-       ([pred] (run-tests pred *ns*))
-       ([pred & namespaces]
-        (let [summary (assoc (apply merge-with + (map #(test-ns pred %)
-                                                      namespaces))
-                             :type :summary)]
-          (t/do-report summary)
-          summary)))
-     
-     ;; Run tests.
-     (defn test-with-formatting
-       [pred formatter namespaces]
-       (case formatter
-         :junit (tj/with-junit-output
-                  (apply run-tests pred namespaces))
-         (apply run-tests pred namespaces)))
-     
-     (defn boot-run-tests
-       [pred output-path formatter namespaces]
-       (if output-path
-         (with-open [writer (io/writer output-path)]
-           (binding [t/*test-out* writer]
-             (test-with-formatting pred formatter namespaces)))
-         (test-with-formatting pred formatter namespaces))))))
-
-
-;;; This prevents a name collision WARNING between the test task and
-;;; clojure.core/test, a function that nobody really uses or cares
-;;; about.
 (if ((loaded-libs) 'boot.user)
   (ns-unmap 'boot.user 'test))
-
 
 (core/deftask test
   "Run clojure.test tests in a pod."
@@ -80,29 +72,34 @@
    o output-path PATH str "A string representing the filepath to output test results to. Defaults to *out*."
    f formatter FORMATTER kw "Tag defining formatter to use with test results. Currently accepts `junit`. Defaults to standard clojure.test output."]
 
-  (let [worker-pods (pod/pod-pool (update-in (core/get-env) [:dependencies] into pod-deps) :init init)]
-    (core/cleanup (worker-pods :shutdown))
-    (core/with-pre-wrap fileset
+  (core/with-pre-wrap fileset
+    (let [input-dirs (core/input-dirs fileset)]
+      (when repeated?
+        (apply namespace-repl/set-refresh-dirs input-dirs)
+        (with-bindings {#'*ns* *ns*}
+          (namespace-repl/refresh)))
       (println "Starting test...")
-      (let [worker-pod (worker-pods :refresh)
+      (let [all-ns (get-all-ns input-dirs)
             namespaces (or (seq namespaces)
-                               (pod/with-eval-in worker-pod
-                                 (-> (get-all-ns ~@(->> fileset
-                                                        core/input-dirs
-                                                        (map (memfn getPath))))
-                                     (filter-namespaces ~limit-regex))))]
+                           (filter-namespaces all-ns limit-regex))]
         (if (seq namespaces)
-          (let [test-predicate `(~'fn [~'%] (and ~@test-filters))
-                summary (pod/with-eval-in worker-pod
-                          (doseq [ns '~namespaces] (require ns))
-                          (boot-run-tests ~test-predicate
-                                          ~output-path
-                                          ~formatter
-                                          '~namespaces))]
+          (let [test-predicate (eval `(~'fn [~'%] (and ~@test-filters)))
+                _ (doseq [ns namespaces] (require ns))
+                summary (boot-run-tests test-predicate
+                                        output-path
+                                        formatter
+                                        namespaces)]
             (println "Test complete.")
             (if (> (apply + (map summary [:fail :error])) 0)
               (throw (ex-info "Failed or errored tests"
                               (dissoc summary :type)))
               (println "Test summary: " (dissoc summary :type))))
           (println "No namespaces were tested."))
+        (when-not repeated?
+          (alter-var-root #'repeated?
+                          (fn [_]
+                            (future
+                              (doseq [ns all-ns]
+                                (require ns)))
+                            true)))
         fileset))))


### PR DESCRIPTION
Rewrote to use `clojure.tools.namespace.repl/refresh` instead of pods.

When using `watch`, pods leak classes, constantly increasing the time it takes tests to run. Using refresh is not a perfect solution but it avoids the class-leak.
